### PR TITLE
Fixes #5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ forge_version_range=[51.0.3,)
 forge_loader_version_range=[51,)
 
 # NeoForge
-neoforge_version=21.0.0-beta
+neoforge_version=21.0.40-beta
 neoforge_version_range=[20.6,)
 neoforge_loader_version_range=[1,)
 

--- a/neoforge/src/main/java/glitchcore/neoforge/handlers/ToolModificationEventHandler.java
+++ b/neoforge/src/main/java/glitchcore/neoforge/handlers/ToolModificationEventHandler.java
@@ -12,8 +12,7 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
-import net.neoforged.fml.common.Mod;
-import net.neoforged.neoforge.common.ToolActions;
+import net.neoforged.neoforge.common.ItemAbilities;
 import net.neoforged.neoforge.event.level.BlockEvent;
 
 import java.util.function.Predicate;
@@ -28,7 +27,7 @@ public class ToolModificationEventHandler
     {
         BlockState originalState = event.getState();
 
-        if (event.getToolAction() == ToolActions.HOE_TILL && tillables.containsKey(originalState.getBlock()))
+        if (event.getItemAbility() == ItemAbilities.HOE_TILL && tillables.containsKey(originalState.getBlock()))
         {
             for (var tillable : tillables.get(originalState.getBlock()))
             {


### PR DESCRIPTION
NeoForge 21.0.40-beta renamed the class. This just fixes that. Ups the minimum neoforge version to 21.0.40-beta

Removed an unused import. Though I'm curious about the unused method? Don't understand NF quite yet. Pretty new to modding. Just fixes the tilling after I crashed while I was working on my 1.21 modpack. <3