### PR TITLE
Fix: Resolve issue #36 - Add Dist.CLIENT to TooltipEventHandler

### DIFF
--- a/forge/src/main/java/glitchcore/forge/handlers/TooltipEventHandler.java
+++ b/forge/src/main/java/glitchcore/forge/handlers/TooltipEventHandler.java
@@ -5,11 +5,12 @@
 package glitchcore.forge.handlers;
 
 import glitchcore.event.EventManager;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.eventbus.api.listener.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
-@Mod.EventBusSubscriber
+@Mod.EventBusSubscriber(value = Dist.CLIENT)
 public class TooltipEventHandler
 {
     @SubscribeEvent


### PR DESCRIPTION
## Description
This PR fixes a compatibility issue that causes crashes when using GlitchCore with Tough As Nails and other mods on Forge 1.21.10.

## Changes
- Added  to the  annotation on TooltipEventHandler
- Added the necessary  import

## Rationale
The ItemTooltipEvent is a client-side event. By explicitly specifying Dist.CLIENT on the EventBusSubscriber, we ensure that this event handler is only registered on the client side, preventing potential conflicts with other mods that may also handle tooltip events.

This follows the same pattern used by other client-side event handlers in the codebase (ColorsEventHandler, EntityRenderersEventHandler, RegisterParticleProvidersEventHandler).

## Testing
- Fixes issue #36 reported by users experiencing crashes with Tough As Nails mod
- Consistent with existing codebase patterns for client-side event handlers

Closes #36