### PR TITLE
[26.1.1] Reduce Optional usage to avoid creating many short-lived objects.

### DIFF
--- a/common/src/main/java/glitchcore/event/EventManager.java
+++ b/common/src/main/java/glitchcore/event/EventManager.java
@@ -39,8 +39,11 @@ public class EventManager
     public static <T extends Event> void fire(T event)
     {
         var eventClass = event.getClass();
+        var listeners = listeners.get(eventClass);
+        if (listeners == null)
+            return;
 
-        for (var listener : Optional.ofNullable(listeners.get(eventClass)).orElse(new Consumer[0]))
+        for (var listener : listeners)
         {
             ((Consumer<T>)listener).accept(event);
 

--- a/fabric/src/main/java/glitchcore/fabric/mixin/client/MixinAbstractContainerScreen.java
+++ b/fabric/src/main/java/glitchcore/fabric/mixin/client/MixinAbstractContainerScreen.java
@@ -28,7 +28,7 @@ public class MixinAbstractContainerScreen
     @Inject(method="extractTooltip", at=@At(value = "HEAD"))
     public void onPreExtractTooltip(GuiGraphicsExtractor guiGraphics, int i, int j, CallbackInfo ci)
     {
-        ((IExtendedGuiGraphics)guiGraphics).setCurrentTooltipStack(Optional.ofNullable(this.hoveredSlot).map(Slot::getItem).orElse(ItemStack.EMPTY));
+        ((IExtendedGuiGraphics)guiGraphics).setCurrentTooltipStack(this.hoveredSlot != null ? this.hoveredSlot.getItem() : ItemStack.EMPTY);
     }
 
     @Inject(method="extractTooltip", at=@At(value = "TAIL"))

--- a/forge/src/main/java/glitchcore/forge/mixin/impl/MixinPacketHandler.java
+++ b/forge/src/main/java/glitchcore/forge/mixin/impl/MixinPacketHandler.java
@@ -58,7 +58,10 @@ public abstract class MixinPacketHandler
                     @Override
                     public Optional<Player> getPlayer()
                     {
-                        return Optional.ofNullable((Player)forgeContext.getSender()).or(() -> isClientSide() ? Optional.ofNullable(Minecraft.getInstance().player) : Optional.empty());
+                        var sender = (Player) forgeContext.getSender();
+                        if (sender != null) return Optional.of(sender);
+                        if (isClientSide()) return Optional.ofNullable(Minecraft.getInstance().player);
+                        return Optional.empty();
                     }
                 });
             });

--- a/neoforge/src/main/java/glitchcore/neoforge/network/GCPayloadFactory.java
+++ b/neoforge/src/main/java/glitchcore/neoforge/network/GCPayloadFactory.java
@@ -64,7 +64,10 @@ public class GCPayloadFactory<T extends CustomPacket<T>>
                     @Override
                     public Optional<Player> getPlayer()
                     {
-                        return Optional.ofNullable(context.player()).or(() -> isClientSide() ? Optional.ofNullable(Minecraft.getInstance().player) : Optional.empty());
+                        var player = context.player();
+                        if (player != null) return Optional.of(player);
+                        if (isClientSide()) return Optional.ofNullable(Minecraft.getInstance().player);
+                        return Optional.empty();
                     }
                 });
             });


### PR DESCRIPTION
Version: 26.1.1

By removing usage of Optional where possible, we can put less pressure on the garbage collector.

This does not change functionality at all, its just faster because it allocates less objects :P