### PR TITLE
[1.21.1] Reduce Optional usage to avoid creating many short-lived objects.

### DIFF
--- a/common/src/main/java/glitchcore/event/EventManager.java
+++ b/common/src/main/java/glitchcore/event/EventManager.java
@@ -39,8 +39,11 @@ public class EventManager
     public static <T extends Event> void fire(T event)
     {
         var eventClass = event.getClass();
+        var listeners = listeners.get(eventClass);
+        if (listeners == null)
+            return;
 
-        for (var listener : Optional.ofNullable(listeners.get(eventClass)).orElse(new Consumer[0]))
+        for (var listener : listeners)
         {
             ((Consumer<T>)listener).accept(event);
 

--- a/fabric/src/main/java/glitchcore/fabric/mixin/client/MixinAbstractContainerScreen.java
+++ b/fabric/src/main/java/glitchcore/fabric/mixin/client/MixinAbstractContainerScreen.java
@@ -25,7 +25,7 @@ public class MixinAbstractContainerScreen
     @Inject(method="renderTooltip", at=@At(value = "INVOKE", target = "net/minecraft/client/gui/GuiGraphics.renderTooltip (Lnet/minecraft/client/gui/Font;Ljava/util/List;Ljava/util/Optional;II)V"))
     public void onPreRenderTooltip(GuiGraphics guiGraphics, int i, int j, CallbackInfo ci)
     {
-        ((IExtendedGuiGraphics)guiGraphics).setCurrentTooltipStack(this.hoveredSlot.getItem());
+        ((IExtendedGuiGraphics)guiGraphics).setCurrentTooltipStack(this.hoveredSlot != null ? this.hoveredSlot.getItem() : ItemStack.EMPTY);
     }
 
     @Inject(method="renderTooltip", at=@At(value = "TAIL"))

--- a/forge/src/main/java/glitchcore/forge/mixin/impl/MixinPacketHandler.java
+++ b/forge/src/main/java/glitchcore/forge/mixin/impl/MixinPacketHandler.java
@@ -57,7 +57,10 @@ public abstract class MixinPacketHandler
                     @Override
                     public Optional<Player> getPlayer()
                     {
-                        return Optional.ofNullable((Player)forgeContext.getSender()).or(() -> isClientSide() ? Optional.ofNullable(Minecraft.getInstance().player) : Optional.empty());
+                        var sender = (Player) forgeContext.getSender();
+                        if (sender != null) return Optional.of(sender);
+                        if (isClientSide()) return Optional.ofNullable(Minecraft.getInstance().player);
+                        return Optional.empty();
                     }
                 });
             });

--- a/neoforge/src/main/java/glitchcore/neoforge/network/GCPayloadFactory.java
+++ b/neoforge/src/main/java/glitchcore/neoforge/network/GCPayloadFactory.java
@@ -64,7 +64,10 @@ public class GCPayloadFactory<T extends CustomPacket<T>>
                     @Override
                     public Optional<Player> getPlayer()
                     {
-                        return Optional.ofNullable(context.player()).or(() -> isClientSide() ? Optional.ofNullable(Minecraft.getInstance().player) : Optional.empty());
+                        var player = context.player();
+                        if (player != null) return Optional.of(player);
+                        if (isClientSide()) return Optional.ofNullable(Minecraft.getInstance().player);
+                        return Optional.empty();
                     }
                 });
             });


### PR DESCRIPTION
Version: 1.21.1

By removing usage of Optional where possible, we can put less pressure on the garbage collector.

This does not change functionality at all, its just faster because it allocates less objects :P